### PR TITLE
Fix crash when both BL and EL have different subsampling

### DIFF
--- a/DoViBaker/AvisynthEntry.cpp
+++ b/DoViBaker/AvisynthEntry.cpp
@@ -18,6 +18,7 @@ AVSValue __cdecl Create_RealDoViBaker(
   bool qnd,
   bool rgbProof,
   bool nlqProof,
+  bool outYUV,
   const AVSValue* args, 
   IScriptEnvironment* env)
 {
@@ -52,6 +53,27 @@ AVSValue __cdecl Create_RealDoViBaker(
     if (elclip && elClipChromaSubSampled < 0) {
       env->ThrowError("DoViBaker: Only 444 and 420 subsampling allowed");
     }
+  }
+
+  if (outYUV) {
+      if (blClipChromaSubSampled != elClipChromaSubSampled) {
+          env->ThrowError("DoViBaker: Both BL and EL must have same chroma subsampling when outYUV=true");
+      }
+      if (!cubeFiles.empty()) {
+          env->ThrowError("DoViBaker: cubes cannot be used when outYUV=true");
+      }
+      if (!nits.empty()) {
+          env->ThrowError("DoViBaker: mclls cannot be used when outYUV=true");
+      }
+      if (!cubesBasePath.empty()) {
+          env->ThrowError("DoViBaker: cubes_basepath cannot be used when outYUV=true");
+      }
+      if (qnd) {
+          env->ThrowError("DoViBaker: qnd cannot be true when outYUV=true");
+      }
+      if (rgbProof) {
+          env->ThrowError("DoViBaker: rgbProof cannot be true when outYUV=true");
+      }
   }
 
   int quarterResolutionEl = 0;
@@ -93,10 +115,10 @@ AVSValue __cdecl Create_RealDoViBaker(
   }
   
   if (quarterResolutionEl == 0) {
-    return new DoViBaker<false>(blclip, elclip, rpuPath, blClipChromaSubSampled, elClipChromaSubSampled, cubeNitsPairs, qnd, rgbProof, nlqProof, env);
+    return new DoViBaker<false>(blclip, elclip, rpuPath, blClipChromaSubSampled, elClipChromaSubSampled, cubeNitsPairs, qnd, rgbProof, nlqProof, outYUV, env);
   }
   if (quarterResolutionEl == 1) {
-    return new DoViBaker<true>(blclip, elclip, rpuPath, blClipChromaSubSampled, elClipChromaSubSampled, cubeNitsPairs, qnd, rgbProof, nlqProof, env);
+    return new DoViBaker<true>(blclip, elclip, rpuPath, blClipChromaSubSampled, elClipChromaSubSampled, cubeNitsPairs, qnd, rgbProof, nlqProof, outYUV, env);
   }
 }
 
@@ -113,6 +135,7 @@ AVSValue __cdecl Create_DoViBaker(AVSValue args, void* user_data, IScriptEnviron
     args[6].AsBool(false),
     args[7].AsBool(false),
     args[8].AsBool(false),
+    args[9].AsBool(false),
     &args, env);
 }
 

--- a/DoViBaker/DoViBaker.cpp
+++ b/DoViBaker/DoViBaker.cpp
@@ -412,7 +412,7 @@ void DoViBaker<quarterResolutionEl>::doAllQuickAndDirty(PVideoFrame& dst, const 
 	elSrcYp[0] = (const uint16_t*)elSrc->GetReadPtr(PLANAR_Y);
 	dstRp[0] = (uint16_t*)dst->GetWritePtr(PLANAR_R);
 
-	const int blUVvsElUVshifts = quarterResolutionEl + elChromaSubsampling - blChromaSubsampling;
+	const int blUVvsElUVshifts = max(quarterResolutionEl + elChromaSubsampling - blChromaSubsampling, 0);
 	std::array<const uint16_t*, (1 << blUVvsElUVshifts)> blSrcUp;
 	std::array<const uint16_t*, 1> elSrcUp;
 	std::array<uint16_t*, (1 << blYvsElUVshifts)> dstGp;

--- a/DoViBaker/DoViBaker.cpp
+++ b/DoViBaker/DoViBaker.cpp
@@ -653,15 +653,28 @@ PVideoFrame DoViBaker<quarterResolutionEl>::GetFrame(int n, IScriptEnvironment* 
 		bool frameChromaSubSampled = blClipChromaSubSampled;
 		if (!skipElProcessing) {
 			if (quarterResolutionEl) {
-				PVideoFrame elUpSrc = env->NewVideoFrame(child->GetVideoInfo());
-				upscaleEl(elUpSrc, elSrc, child->GetVideoInfo(), env);
+				PVideoFrame elUpSrc;
+				if (!blClipChromaSubSampled && elClipChromaSubSampled) {
+					VideoInfo vi420 = child->GetVideoInfo();
+					vi420.pixel_type = VideoInfo::CS_YUV420P16;
+					elUpSrc = env->NewVideoFrame(vi420);
+					upscaleEl(elUpSrc, elSrc, vi420, env);
+				}
+				else if (blClipChromaSubSampled && !elClipChromaSubSampled) {
+					VideoInfo vi444 = child->GetVideoInfo();
+					vi444.pixel_type = VideoInfo::CS_YUV444P16;
+					elUpSrc = env->NewVideoFrame(vi444);
+					upscaleEl(elUpSrc, elSrc, vi444, env);
+				}
+				else {
+					elUpSrc = env->NewVideoFrame(child->GetVideoInfo());
+					upscaleEl(elUpSrc, elSrc, child->GetVideoInfo(), env);
+				}
 				elSrc = elUpSrc;
 			}
 			if (!blClipChromaSubSampled && elClipChromaSubSampled) {
-				VideoInfo vi444 = elChild->GetVideoInfo();
-				vi444.pixel_type = VideoInfo::CS_YUV444P16;
-				elSrc444 = env->NewVideoFrame(vi444);
-				upsampleChroma(elSrc444, elSrc, vi444, env);
+				elSrc444 = env->NewVideoFrame(child->GetVideoInfo());
+				upsampleChroma(elSrc444, elSrc, child->GetVideoInfo(), env);
 				frameChromaSubSampled = false;
 			}
 			if (blClipChromaSubSampled && !elClipChromaSubSampled) {
@@ -674,7 +687,16 @@ PVideoFrame DoViBaker<quarterResolutionEl>::GetFrame(int n, IScriptEnvironment* 
 		}
 		else { elSrcR = blSrc; }
 
-		PVideoFrame mez = env->NewVideoFrame(child->GetVideoInfo());
+		PVideoFrame mez = [&]() {
+			if (blClipChromaSubSampled && !elClipChromaSubSampled) {
+				VideoInfo vi444 = child->GetVideoInfo();
+				vi444.pixel_type = VideoInfo::CS_YUV444P16;
+				return env->NewVideoFrame(vi444);
+			}
+			else {
+				return env->NewVideoFrame(child->GetVideoInfo());
+			}
+		}();
 		if (frameChromaSubSampled)
 			applyDovi<true>(mez, blSrc, (!blSrc444) ? blSrc : blSrc444, elSrcR, (!elSrc444) ? elSrcR : elSrc444, env);
 		else

--- a/DoViBaker/DoViBaker.cpp
+++ b/DoViBaker/DoViBaker.cpp
@@ -67,8 +67,6 @@ inline void DoViBaker<quarterResolutionEl>::upsampleVert(PVideoFrame& dst, const
 	const int srcPitch = src->GetPitch(plane) / sizeof(uint16_t);
 	const uint16_t* srcPb = (const uint16_t*)src->GetReadPtr(plane);
 
-	const int dstHeight = dst->GetHeight(plane);
-	const int dstWidth = dst->GetRowSize(plane) / sizeof(uint16_t);
 	const int dstPitch = dst->GetPitch(plane) / sizeof(uint16_t);
 	uint16_t* dstPeven = (uint16_t*)dst->GetWritePtr(plane);
 	uint16_t* dstPodd = dstPeven + dstPitch;
@@ -110,8 +108,6 @@ void DoViBaker<quarterResolutionEl>::upsampleHorz(PVideoFrame& dst, const PVideo
 	const int srcPitch = src->GetPitch(plane) / sizeof(uint16_t);
 	const uint16_t* srcP = (const uint16_t*)src->GetReadPtr(plane);
 
-	const int dstHeight = dst->GetHeight(plane);
-	const int dstWidth = dst->GetRowSize(plane) / sizeof(uint16_t);
 	const int dstPitch = dst->GetPitch(plane) / sizeof(uint16_t);
 	uint16_t* dstP = (uint16_t*)dst->GetWritePtr(plane);
 
@@ -269,16 +265,10 @@ template<int quarterResolutionEl>
 template<int chromaSubsampling>
 void DoViBaker<quarterResolutionEl>::applyDovi(PVideoFrame& dst, const PVideoFrame& blSrcY, const PVideoFrame& blSrcUV, const PVideoFrame& elSrcY, const PVideoFrame& elSrcUV, IScriptEnvironment* env) const {
 
-	const int blSrcHeightY = blSrcY->GetHeight(PLANAR_Y);
-	const int blSrcWidthY = blSrcY->GetRowSize(PLANAR_Y) / sizeof(uint16_t);
 	const int blSrcPitchY = blSrcY->GetPitch(PLANAR_Y) / sizeof(uint16_t);
 
-	const int elSrcHeightY = elSrcY->GetHeight(PLANAR_Y);
-	const int elSrcWidthY = elSrcY->GetRowSize(PLANAR_Y) / sizeof(uint16_t);
 	const int elSrcPitchY = elSrcY->GetPitch(PLANAR_Y) / sizeof(uint16_t);
 
-	const int dstHeightY = dst->GetHeight(PLANAR_Y);
-	const int dstWidthY = dst->GetRowSize(PLANAR_Y) / sizeof(uint16_t);
 	const int dstPitchY = dst->GetPitch(PLANAR_Y) / sizeof(uint16_t);
 
 	std::array<const uint16_t*, chromaSubsampling + 1> blSrcYp;
@@ -298,12 +288,8 @@ void DoViBaker<quarterResolutionEl>::applyDovi(PVideoFrame& dst, const PVideoFra
 	const int blSrcWidthUV = blSrcUV->GetRowSize(PLANAR_U) / sizeof(uint16_t);
 	const int blSrcPitchUV = blSrcUV->GetPitch(PLANAR_U) / sizeof(uint16_t);
 
-	const int elSrcHeightUV = elSrcUV->GetHeight(PLANAR_U);
-	const int elSrcWidthUV = elSrcUV->GetRowSize(PLANAR_U) / sizeof(uint16_t);
 	const int elSrcPitchUV = elSrcUV->GetPitch(PLANAR_U) / sizeof(uint16_t);
 
-	const int dstHeightUV = dst->GetHeight(PLANAR_U);
-	const int dstWidthUV = dst->GetRowSize(PLANAR_U) / sizeof(uint16_t);
 	const int dstPitchUV = dst->GetPitch(PLANAR_U) / sizeof(uint16_t);
 
 	const uint16_t* blSrcUp = (const uint16_t*)blSrcUV->GetReadPtr(PLANAR_U);
@@ -384,20 +370,12 @@ void DoViBaker<quarterResolutionEl>::applyDovi(PVideoFrame& dst, const PVideoFra
 template<int quarterResolutionEl>
 template<int blChromaSubsampling, int elChromaSubsampling>
 void DoViBaker<quarterResolutionEl>::doAllQuickAndDirty(PVideoFrame& dst, const PVideoFrame& blSrc, const PVideoFrame& elSrc, IScriptEnvironment* env) const {
-	const int blSrcHeightY = blSrc->GetHeight(PLANAR_Y);
-	const int blSrcWidthY = blSrc->GetRowSize(PLANAR_Y) / sizeof(uint16_t);
 	const int blSrcPitchY = blSrc->GetPitch(PLANAR_Y) / sizeof(uint16_t);
 
-	const int elSrcHeightY = elSrc->GetHeight(PLANAR_Y);
-	const int elSrcWidthY = elSrc->GetRowSize(PLANAR_Y) / sizeof(uint16_t);
 	const int elSrcPitchY = elSrc->GetPitch(PLANAR_Y) / sizeof(uint16_t);
 
-	const int dstHeight = dst->GetHeight(PLANAR_R);
-	const int dstWidth = dst->GetRowSize(PLANAR_R) / sizeof(uint16_t);
 	const int dstPitch = dst->GetPitch(PLANAR_R) / sizeof(uint16_t);
 
-	const int blSrcHeightUV = blSrc->GetHeight(PLANAR_U);
-	const int blSrcWidthUV = blSrc->GetRowSize(PLANAR_U) / sizeof(uint16_t);
 	const int blSrcPitchUV = blSrc->GetPitch(PLANAR_U) / sizeof(uint16_t);
 
 	const int elSrcHeightUV = elSrc->GetHeight(PLANAR_U);
@@ -507,12 +485,8 @@ void DoViBaker<quarterResolutionEl>::doAllQuickAndDirty(PVideoFrame& dst, const 
 template<int quarterResolutionEl>
 void DoViBaker<quarterResolutionEl>::convert2rgb(PVideoFrame& dst, const PVideoFrame& srcY, const PVideoFrame& srcUV) const
 {
-	const int srcHeightY = srcY->GetHeight(PLANAR_Y);
-	const int srcWidthY = srcY->GetRowSize(PLANAR_Y) / sizeof(uint16_t);
 	const int srcPitchY = srcY->GetPitch(PLANAR_Y) / sizeof(uint16_t);
 
-	const int dstHeight = dst->GetHeight(PLANAR_R);
-	const int dstWidth = dst->GetRowSize(PLANAR_R) / sizeof(uint16_t);
 	const int dstPitch = dst->GetPitch(PLANAR_R) / sizeof(uint16_t);
 
 	const uint16_t* srcYp = (const uint16_t*)srcY->GetReadPtr(PLANAR_Y);

--- a/DoViBaker/lut.cpp
+++ b/DoViBaker/lut.cpp
@@ -83,19 +83,9 @@ Vector3 operator+(const Vector3 &lhs, const Vector3 &rhs)
 	return{ lhs[0] + rhs[0], lhs[1] + rhs[1], lhs[2] + rhs[2] };
 }
 
-Vector3 operator-(const Vector3 &lhs, const Vector3 &rhs)
-{
-	return{ lhs[0] - rhs[0], lhs[1] - rhs[1], lhs[2] - rhs[2] };
-}
-
 Vector3 operator*(float lhs, const Vector3 &rhs)
 {
 	return{ lhs * rhs[0], lhs * rhs[1], lhs * rhs[2] };
-}
-
-Vector3 operator*(const Vector3 &lhs, float rhs)
-{
-	return rhs * lhs;
 }
 
 template <class T>

--- a/include/DoViBaker.h
+++ b/include/DoViBaker.h
@@ -22,7 +22,8 @@ public:
     std::vector<std::pair<uint16_t, std::string>> &cubes, 
     bool qnd, 
     bool rgbProof, 
-    bool nlqProof, 
+    bool nlqProof,
+    bool outYUV,
     IScriptEnvironment* env);
   virtual ~DoViBaker();
   PVideoFrame GetFrame(int n, IScriptEnvironment* env) override;
@@ -52,6 +53,7 @@ private:
   int CPU_FLAG;
   DoViProcessor* doviProc;
   const bool qnd;
+  const bool outYUV;
   const bool blClipChromaSubSampled;
   const bool elClipChromaSubSampled;
   std::vector<std::pair<uint16_t, std::unique_ptr<timecube::Lut>>> luts;


### PR DESCRIPTION
This should fix the crash when both BL and EL have different subsampling.

Btw there is vertical chroma shift when BL is 420.