### PR TITLE
Migrate to libdovi 3.0 and allow processing with no EL

### DIFF
--- a/DoViBaker/DoViProcessor.cpp
+++ b/DoViBaker/DoViProcessor.cpp
@@ -83,121 +83,80 @@ bool DoViProcessor::intializeFrame(int frame, IScriptEnvironment* env) {
 		return false;
 	}
 
-	if (header->guessed_profile != 7) {
-		showMessage("DoViBaker: Expecting profile 7 rpu data.", env);
-		return false;
-	}
-	
-	std::string subprofile(header->subprofile);
-	std::transform(subprofile.begin(), subprofile.end(), subprofile.begin(),
-		[](unsigned char c) { return std::toupper(c); });
-	is_fel = (subprofile.compare("FEL")==0);
-
-	auto num_pivots_minus2 = header->num_pivots_minus_2;
-	auto pred_pivot_value = header->pred_pivot_value;
-	for (int cmp = 0; cmp < 3; cmp++) {
-		num_pivots_minus1[cmp] = num_pivots_minus2[cmp] + 1;
-		pivot_value[cmp] = std::vector<uint16_t>(num_pivots_minus1[cmp] + 1);
-		pivot_value[cmp][0] = pred_pivot_value[cmp].data[0];
-		for (int pivot_idx = 1; pivot_idx < num_pivots_minus1[cmp] + 1; pivot_idx++) {
-			pivot_value[cmp][pivot_idx] = pivot_value[cmp][pivot_idx - 1] + pred_pivot_value[cmp].data[pivot_idx];
-		}
-	}
-
-	out_bit_depth = header->vdr_bit_depth_minus_8 + 8;
-	bl_bit_depth = header->bl_bit_depth_minus8 + 8;
-	el_bit_depth = header->el_bit_depth_minus8 + 8;
-	coeff_log2_denom = header->coefficient_log2_denom;
-	disable_residual_flag = header->disable_residual_flag;
-
-	if (header->nlq_method_idc != 0) {
-		//https://ffmpeg.org/doxygen/trunk/dovi__rpu_8c_source.html
-		showMessage("DoViBaker: Only method NLQ_LINEAR_DZ can be applied, NLQ_MU_LAW is not documented.", env);
-		return false;
-		//alternativlely we could just gracefully disable the nlq processing with disable_residual_flag=true
-	}
-	if (header->nlq_num_pivots_minus2 != 0) {
-		showMessage("DoViBaker: Expecting nlq_num_pivots_minus2 to be 0.", env);
-		return false;
-		//alternativlely we could just gracefully disable the nlq processing with disable_residual_flag=true
-	}
-
 	const DoviRpuDataMapping* mapping_data = dovi_rpu_get_data_mapping(rpu);
 	if (!mapping_data) {
 		const char* error = dovi_rpu_get_error(rpu);
 		showMessage((std::string("DoViBaker: ") + error).c_str(), env);
 		return false;
 	}
-	auto poly_order_minus1 = mapping_data->poly_order_minus1;
-	auto poly_coef_int = mapping_data->poly_coef_int;
-	auto poly_coef = mapping_data->poly_coef;
+
+	out_bit_depth = header->vdr_bit_depth_minus8 + 8;
+	bl_bit_depth = header->bl_bit_depth_minus8 + 8;
+	el_bit_depth = header->el_bit_depth_minus8 + 8;
+	coeff_log2_denom = header->coefficient_log2_denom;
+	disable_residual_flag = header->disable_residual_flag;
+
 	for (int cmp = 0; cmp < 3; cmp++) {
+        const DoviReshapingCurve curve = mapping_data->curves[cmp];
+		num_pivots_minus1[cmp] = curve.num_pivots_minus2 + 1;
+
+		pivot_value[cmp] = std::vector<uint16_t>(curve.pivots.len);
+		pivot_value[cmp][0] = curve.pivots.data[0];
+
+		for (int pivot_idx = 1; pivot_idx < curve.pivots.len; pivot_idx++) {
+			pivot_value[cmp][pivot_idx] = pivot_value[cmp][pivot_idx - 1] + curve.pivots.data[pivot_idx];
+		}
+
 		mapping_idc[cmp] = std::vector<uint8_t>(num_pivots_minus1[cmp]);
 		poly_order[cmp] = std::vector<uint8_t>(num_pivots_minus1[cmp]);
 		fp_poly_coef[cmp] = std::vector<std::vector<int32_t>>(num_pivots_minus1[cmp]);
-		for (int pivot_idx = 0; pivot_idx < num_pivots_minus1[cmp]; pivot_idx++) {
-			mapping_idc[cmp][pivot_idx] = mapping_data->mapping_idc[cmp].data[0];
-			if (mapping_idc[cmp][pivot_idx] != 0) continue;
-			poly_order[cmp][pivot_idx] = poly_order_minus1[cmp].data[pivot_idx] + 1; 
-			fp_poly_coef[cmp][pivot_idx] = std::vector<int32_t>(poly_order[cmp][pivot_idx] + 1); // an order n equation has n+1 coefficients, thus +1!
-			for (int coeff = 0; coeff < poly_order[cmp][pivot_idx] + 1; coeff++) {  // an order n equation has n+1 coefficients, thus +1!
-				auto port_int = poly_coef_int[cmp].list[pivot_idx]->data[coeff];
-				auto port_frac = poly_coef[cmp].list[pivot_idx]->data[coeff];
-				fp_poly_coef[cmp][pivot_idx][coeff] = (port_int << coeff_log2_denom) + port_frac;
-			}
-		}
-	}
 
-	auto mmr_order_minus1 = mapping_data->mmr_order_minus1;
-	auto mmr_constant_int = mapping_data->mmr_constant_int;
-	auto mmr_constant = mapping_data->mmr_constant;
-	auto mmr_coef_int = mapping_data->mmr_coef_int;
-	auto mmr_coef = mapping_data->mmr_coef;
-
-	for (int cmp = 0; cmp < 3; cmp++) {
 		mmr_order[cmp] = std::vector<uint8_t>(num_pivots_minus1[cmp]);
 		fp_mmr_const[cmp] = std::vector<int32_t>(num_pivots_minus1[cmp]);
 		fp_mmr_coef[cmp] = std::vector<std::vector<std::vector<int32_t>>>(num_pivots_minus1[cmp]);
+
 		for (int pivot_idx = 0; pivot_idx < num_pivots_minus1[cmp]; pivot_idx++) {
-			if (mapping_idc[cmp][pivot_idx] != 1) continue;
-			mmr_order[cmp][pivot_idx] = mmr_order_minus1[cmp].data[pivot_idx] + 1;
-			auto constant_int = mmr_constant_int[cmp].data[pivot_idx];
-			auto constant = mmr_constant[cmp].data[pivot_idx];
-			fp_mmr_const[cmp][pivot_idx] = (constant_int << coeff_log2_denom) + constant;
-			fp_mmr_coef[cmp][pivot_idx] = std::vector<std::vector<int32_t>>(mmr_order[cmp][pivot_idx] + 1); // an order n equation has n+1 coefficients, thus +1!
-			for (int i = 0; i < mmr_order[cmp][pivot_idx] + 1; i++) { // an order n equation has n+1 coefficients, thus +1!
-				fp_mmr_coef[cmp][pivot_idx][i] = std::vector<int32_t>(7);
-				for (int j = 0; j < 7; j++) {
-					auto port_int = mmr_coef_int[cmp].list[pivot_idx]->list[i]->data[j];
-					auto port_frac = mmr_coef[cmp].list[pivot_idx]->list[i]->data[j];
-					fp_mmr_coef[cmp][pivot_idx][i][j] = (port_int << coeff_log2_denom) + port_frac;
+			mapping_idc[cmp][pivot_idx] = curve.mapping_idc;
+
+			if (curve.polynomial) {
+				const DoviPolynomialCurve *poly_curve = curve.polynomial;
+				
+				auto poly_order_minus1 = poly_curve->poly_order_minus1;
+				auto poly_coef_int = poly_curve->poly_coef_int;
+				auto poly_coef = poly_curve->poly_coef;
+
+				poly_order[cmp][pivot_idx] = poly_order_minus1.data[pivot_idx] + 1; 
+				fp_poly_coef[cmp][pivot_idx] = std::vector<int32_t>(poly_order[cmp][pivot_idx] + 1); // an order n equation has n+1 coefficients, thus +1!
+				for (int coeff = 0; coeff < poly_order[cmp][pivot_idx] + 1; coeff++) {  // an order n equation has n+1 coefficients, thus +1!
+					auto port_int = poly_coef_int.list[pivot_idx]->data[coeff];
+					auto port_frac = poly_coef.list[pivot_idx]->data[coeff];
+					fp_poly_coef[cmp][pivot_idx][coeff] = (port_int << coeff_log2_denom) + port_frac;
+				}
+			} else if (curve.mmr) {
+				const DoviMMRCurve *mmr_curve = curve.mmr;
+
+				auto mmr_order_minus1 = mmr_curve->mmr_order_minus1;
+				auto mmr_constant_int = mmr_curve->mmr_constant_int;
+				auto mmr_constant = mmr_curve->mmr_constant;
+				auto mmr_coef_int = mmr_curve->mmr_coef_int;
+				auto mmr_coef = mmr_curve->mmr_coef;
+
+				mmr_order[cmp][pivot_idx] = mmr_order_minus1.data[pivot_idx] + 1;
+				auto constant_int = mmr_constant_int.data[pivot_idx];
+				auto constant = mmr_constant.data[pivot_idx];
+				fp_mmr_const[cmp][pivot_idx] = (constant_int << coeff_log2_denom) + constant;
+				fp_mmr_coef[cmp][pivot_idx] = std::vector<std::vector<int32_t>>(mmr_order[cmp][pivot_idx]);
+
+				for (int i = 0; i < mmr_order[cmp][pivot_idx]; i++) {
+					fp_mmr_coef[cmp][pivot_idx][i] = std::vector<int32_t>(7);
+					for (int j = 0; j < 7; j++) {
+						auto port_int = mmr_coef_int.list[pivot_idx]->list[i]->data[j];
+						auto port_frac = mmr_coef.list[pivot_idx]->list[i]->data[j];
+						fp_mmr_coef[cmp][pivot_idx][i][j] = (port_int << coeff_log2_denom) + port_frac;
+					}
 				}
 			}
 		}
-	}
-
-	const DoviRpuDataNlq* nlq_data = dovi_rpu_get_data_nlq(rpu);
-	if (!nlq_data) {
-		const char* error = dovi_rpu_get_error(rpu);
-		showMessage((std::string("DoViBaker: ") + error).c_str(), env);
-		return false;
-	}
-	auto nlq_offsets = nlq_data->nlq_offset.list[0];
-	auto vdr_in_max_int = nlq_data->vdr_in_max_int.list[0];
-	auto vdr_in_max = nlq_data->vdr_in_max.list[0];
-	auto linear_deadzone_slope_int = nlq_data->linear_deadzone_slope_int.list[0];
-	auto linear_deadzone_slope = nlq_data->linear_deadzone_slope.list[0];
-	auto linear_deadzone_threshold_int = nlq_data->linear_deadzone_threshold_int.list[0];
-	auto linear_deadzone_threshold = nlq_data->linear_deadzone_threshold.list[0];
-
-	for (int cmp = 0; cmp < 3; cmp++) {
-		nlq_offset[cmp] = nlq_offsets->data[cmp];
-		fp_hdr_in_max[cmp] = (vdr_in_max_int->data[cmp] << coeff_log2_denom) + vdr_in_max->data[cmp];
-		fp_linear_deadzone_slope[cmp] = (linear_deadzone_slope_int->data[cmp] << coeff_log2_denom) + linear_deadzone_slope->data[cmp];
-		fp_linear_deadzone_threshold[cmp] = (linear_deadzone_threshold_int->data[cmp] << coeff_log2_denom) + linear_deadzone_threshold->data[cmp];
-	}
-	if (nlqProof) {
-		fp_linear_deadzone_slope[0] *= 4;
 	}
 
 	if (header->vdr_dm_metadata_present_flag) {
@@ -267,8 +226,55 @@ bool DoViProcessor::intializeFrame(int frame, IScriptEnvironment* env) {
 		return false;
 	}
 
+	if (header->guessed_profile != 7) {
+		dovi_rpu_free_data_mapping(mapping_data);
+		dovi_rpu_free_header(header);
+		return successfulCreation;
+	}
+
+	const DoviRpuDataNlq* nlq_data = mapping_data->nlq;
+	if (!nlq_data) {
+		const char* error = dovi_rpu_get_error(rpu);
+		showMessage((std::string("DoViBaker: ") + error).c_str(), env);
+		return false;
+	}
+
+	if (mapping_data->nlq_method_idc != 0) {
+		//https://ffmpeg.org/doxygen/trunk/dovi__rpu_8c_source.html
+		showMessage("DoViBaker: Only method NLQ_LINEAR_DZ can be applied, NLQ_MU_LAW is not documented.", env);
+		return false;
+		//alternativlely we could just gracefully disable the nlq processing with disable_residual_flag=true
+	}
+	if (mapping_data->nlq_num_pivots_minus2 != 0) {
+		showMessage("DoViBaker: Expecting nlq_num_pivots_minus2 to be 0.", env);
+		return false;
+		//alternativlely we could just gracefully disable the nlq processing with disable_residual_flag=true
+	}
+
+	std::string el_type(header->el_type);
+	std::transform(el_type.begin(), el_type.end(), el_type.begin(),
+		[](unsigned char c) { return std::toupper(c); });
+	is_fel = (el_type.compare("FEL")==0);
+
+	auto nlq_offsets = nlq_data->nlq_offset;
+	auto vdr_in_max_int = nlq_data->vdr_in_max_int;
+	auto vdr_in_max = nlq_data->vdr_in_max;
+	auto linear_deadzone_slope_int = nlq_data->linear_deadzone_slope_int;
+	auto linear_deadzone_slope = nlq_data->linear_deadzone_slope;
+	auto linear_deadzone_threshold_int = nlq_data->linear_deadzone_threshold_int;
+	auto linear_deadzone_threshold = nlq_data->linear_deadzone_threshold;
+
+	for (int cmp = 0; cmp < 3; cmp++) {
+		nlq_offset[cmp] = nlq_offsets[cmp];
+		fp_hdr_in_max[cmp] = (vdr_in_max_int[cmp] << coeff_log2_denom) + vdr_in_max[cmp];
+		fp_linear_deadzone_slope[cmp] = (linear_deadzone_slope_int[cmp] << coeff_log2_denom) + linear_deadzone_slope[cmp];
+		fp_linear_deadzone_threshold[cmp] = (linear_deadzone_threshold_int[cmp] << coeff_log2_denom) + linear_deadzone_threshold[cmp];
+	}
+	if (nlqProof) {
+		fp_linear_deadzone_slope[0] *= 4;
+	}
+
 	dovi_rpu_free_data_mapping(mapping_data);
-	dovi_rpu_free_data_nlq(nlq_data);
 	dovi_rpu_free_header(header);
 	return successfulCreation;
 }
@@ -377,7 +383,7 @@ uint16_t DoViProcessor::mmrMapping(int cmp, int pivot_idx, uint16_t s0, uint16_t
 	}
 	int64_t rr = fp_mmr_const[cmp][pivot_idx] * tt[0];
 	int cnt = 1;
-	for (int i = 1; i <= mmr_order[cmp][pivot_idx]; i++) {
+	for (int i = 0; i < mmr_order[cmp][pivot_idx]; i++) {
 		for (int j = 0; j < 7; j++) {
 			rr += fp_mmr_coef[cmp][pivot_idx][i][j] * tt[cnt];
 			cnt++;

--- a/DoViBaker/DoViProcessor.cpp
+++ b/DoViBaker/DoViProcessor.cpp
@@ -34,8 +34,6 @@ DoViProcessor::DoViProcessor(const char* rpuPath, IScriptEnvironment* env)
 	dovi_rpu_list_free = (f_dovi_rpu_list_free)GetProcAddress(doviLib, "dovi_rpu_list_free");
 	dovi_rpu_get_header = (f_dovi_rpu_get_header)GetProcAddress(doviLib, "dovi_rpu_get_header");
 	dovi_rpu_free_header = (f_dovi_rpu_free_header)GetProcAddress(doviLib, "dovi_rpu_free_header");
-	dovi_rpu_get_data_nlq = (f_dovi_rpu_get_data_nlq)GetProcAddress(doviLib, "dovi_rpu_get_data_nlq");
-	dovi_rpu_free_data_nlq = (f_dovi_rpu_free_data_nlq)GetProcAddress(doviLib, "dovi_rpu_free_data_nlq");
 	dovi_rpu_get_vdr_dm_data = (f_dovi_rpu_get_vdr_dm_data)GetProcAddress(doviLib, "dovi_rpu_get_vdr_dm_data");
 	dovi_rpu_free_vdr_dm_data = (f_dovi_rpu_free_vdr_dm_data)GetProcAddress(doviLib, "dovi_rpu_free_vdr_dm_data");
 	dovi_rpu_get_data_mapping = (f_dovi_rpu_get_data_mapping)GetProcAddress(doviLib, "dovi_rpu_get_data_mapping");

--- a/include/DoViProcessor.h
+++ b/include/DoViProcessor.h
@@ -13,8 +13,6 @@ typedef void (*f_dovi_rpu_list_free)(DoviRpuOpaqueList* ptr);
 typedef const char* (*f_dovi_rpu_get_error)(const DoviRpuOpaque* ptr);
 typedef const DoviRpuDataHeader* (*f_dovi_rpu_get_header)(const DoviRpuOpaque* ptr);
 typedef void (*f_dovi_rpu_free_header)(const DoviRpuDataHeader* ptr);
-typedef const DoviRpuDataNlq* (*f_dovi_rpu_get_data_nlq)(const DoviRpuOpaque* ptr);
-typedef void (*f_dovi_rpu_free_data_nlq)(const DoviRpuDataNlq* ptr);
 typedef const DoviRpuDataMapping* (*f_dovi_rpu_get_data_mapping)(const DoviRpuOpaque* ptr);
 typedef void (*f_dovi_rpu_free_data_mapping)(const DoviRpuDataMapping* ptr);
 typedef const DoviVdrDmData* (*f_dovi_rpu_get_vdr_dm_data)(const DoviRpuOpaque* ptr);
@@ -91,8 +89,6 @@ private:
   f_dovi_rpu_list_free dovi_rpu_list_free;
   f_dovi_rpu_get_header dovi_rpu_get_header;
   f_dovi_rpu_free_header dovi_rpu_free_header;
-  f_dovi_rpu_get_data_nlq dovi_rpu_get_data_nlq;
-  f_dovi_rpu_free_data_nlq dovi_rpu_free_data_nlq;
   f_dovi_rpu_get_vdr_dm_data dovi_rpu_get_vdr_dm_data;
   f_dovi_rpu_free_vdr_dm_data dovi_rpu_free_vdr_dm_data;
   f_dovi_rpu_get_data_mapping dovi_rpu_get_data_mapping;


### PR DESCRIPTION
Couple of changes here:
- Migrated to `libdovi` 3.0+ structs.
- Allow processing Dolby Vision profiles without NLQ.

I've updated the header and I've been told this should be enough to build and dynamically link to `dovi.dll`.
Of course it would be better to statically link, as was done in https://github.com/Asd-g/DoViBaker.

If you need the DLL to test: [libdovi-3.1.1-x86_64-pc-windows-msvc.zip](https://github.com/erazortt/DoViBaker/files/10810040/libdovi-3.1.1-x86_64-pc-windows-msvc.zip)
It's likely some things break when the RPU is not profile 7, but I've only tested processing frames with AVS+. Not the CLI util, LUTs or tone mapping.