### PR TITLE
Read instream rpu, compatible to ffms2

### DIFF
--- a/DoViBaker/AvisynthEntry.cpp
+++ b/DoViBaker/AvisynthEntry.cpp
@@ -64,6 +64,7 @@ AVSValue __cdecl Create_RealDoViBaker(
       env->ThrowError("DoViBaker: Enhancement Layer must either be same size or quarter size as Base Layer");
     }
   }
+  
   std::stringstream ssCubeFiles(cubeFiles);
   std::vector<std::string> cubesList;
   std::string segment;
@@ -130,10 +131,10 @@ extern "C" __declspec(dllexport) const char* __stdcall AvisynthPluginInit3(IScri
 }
 
 void ypp2ycc(uint16_t* ycc, float y, float u, float v) {
-  static const uint16_t scale = 1 << DoViProcessor::containerBitDepth;
-  static const uint16_t bias = 16 << (DoViProcessor::containerBitDepth - 8);
-  static const uint16_t ltop = scale - (21 << (DoViProcessor::containerBitDepth - 8));
-  static const uint16_t ctop = scale - (16 << (DoViProcessor::containerBitDepth - 8));
+  static const uint16_t scale = 1 << DoViProcessor::outContainerBitDepth;
+  static const uint16_t bias = 16 << (DoViProcessor::outContainerBitDepth - 8);
+  static const uint16_t ltop = scale - (21 << (DoViProcessor::outContainerBitDepth - 8));
+  static const uint16_t ctop = scale - (16 << (DoViProcessor::outContainerBitDepth - 8));
 
   ycc[0] = y * (ltop - bias) + bias;
   ycc[1] = (u + 0.5) * (ctop - bias) + bias;
@@ -142,7 +143,7 @@ void ypp2ycc(uint16_t* ycc, float y, float u, float v) {
 
 inline uint16_t to8bits(uint16_t sample) {
   // we just check for 8bit precicion deviations, assuming smaller differences to be not visible
-  return (sample >> (DoViProcessor::containerBitDepth - 8));
+  return (sample >> (DoViProcessor::outContainerBitDepth - 8));
 }
 
 bool checkElProcessing(const DoViProcessor &dovi) {
@@ -163,7 +164,7 @@ uint16_t checkMatrix(const DoViProcessor& dovi) {
   uint16_t rgb[3];
   uint16_t diffBits = 0;
 
-  static const uint16_t maxNormRGB = 255 << (DoViProcessor::containerBitDepth - 8);
+  static const uint16_t maxNormRGB = 255 << (DoViProcessor::outContainerBitDepth - 8);
   static const uint16_t halfNormRGB = maxNormRGB >> 1;
 
   ypp2ycc(yuv, 1.0000, 0.0000, 0.0000);
@@ -302,7 +303,7 @@ int main(int argc, char** argv)
     return 1;
   }
   
-  DoViProcessor dovi(argv[1], NULL);
+  DoViProcessor dovi(argv[1], NULL, DoViProcessor::outContainerBitDepth, DoViProcessor::outContainerBitDepth);
   if (!dovi.wasCreationSuccessful()) {
     return 1;
   }

--- a/DoViBaker/AvisynthEntry.cpp
+++ b/DoViBaker/AvisynthEntry.cpp
@@ -322,7 +322,7 @@ int main(int argc, char** argv)
   bool limitedRangeOutput = false;
   std::vector<uint16_t> trimPq;
   for (int i = 0; i < length; i++) {
-    if (!dovi.intializeFrame(i, NULL)) {
+    if (!dovi.intializeFrame(i, NULL, 0, 0)) {
       return 1;
     }
     int frame_max_pq = dovi.getMaxPq();

--- a/DoViBaker/DoViProcessor.cpp
+++ b/DoViBaker/DoViProcessor.cpp
@@ -5,13 +5,15 @@
 #include "DoViProcessor.h"
 
 
-DoViProcessor::DoViProcessor(const char* rpuPath, IScriptEnvironment* env)
+DoViProcessor::DoViProcessor(const char* rpuPath, IScriptEnvironment* env, uint8_t blContainerBits, uint8_t elContainerBits)
 	: successfulCreation(false)
 	, rgbProof(false)
 	, nlqProof(false)
 	, desiredTrimPq(0)
 	, max_content_light_level(1000)
 	, rpus(0x0)
+	, blContainerBitDepth(blContainerBits)
+	, elContainerBitDepth(elContainerBits)
 {
 	ycc_to_rgb_coef[0] = 8192;
 	ycc_to_rgb_coef[1] = 0;
@@ -24,8 +26,8 @@ DoViProcessor::DoViProcessor(const char* rpuPath, IScriptEnvironment* env)
 	ycc_to_rgb_coef[8] = 0;
 
 	ycc_to_rgb_offset[0] = 0;
-	ycc_to_rgb_offset[1] = (1 << (containerBitDepth - 1)) << ycc_to_rgb_offset_scale_shifts;
-	ycc_to_rgb_offset[2] = (1 << (containerBitDepth - 1)) << ycc_to_rgb_offset_scale_shifts;
+	ycc_to_rgb_offset[1] = (1 << (outContainerBitDepth - 1)) << ycc_to_rgb_offset_scale_shifts;
+	ycc_to_rgb_offset[2] = (1 << (outContainerBitDepth - 1)) << ycc_to_rgb_offset_scale_shifts;
 
 	doviLib = ::LoadLibrary(L"dovi.dll"); // delayed loading, original name
 	if (doviLib == NULL) {
@@ -115,6 +117,15 @@ bool DoViProcessor::intializeFrame(int frame, IScriptEnvironment* env, const uin
 	el_bit_depth = header->el_bit_depth_minus8 + 8;
 	coeff_log2_denom = header->coefficient_log2_denom;
 	disable_residual_flag = header->disable_residual_flag;
+
+	if (blContainerBitDepth < bl_bit_depth) {
+		showMessage("DoViBaker: BL stream needs higher bitdepth", env);
+		return false;
+	}
+	if ((!elProcessingDisabled()) && elContainerBitDepth < el_bit_depth) {
+		showMessage("DoViBaker: EL stream needs higher bitdepth", env);
+		return false;
+	}
 
 	for (int cmp = 0; cmp < 3; cmp++) {
         const DoviReshapingCurve curve = mapping_data->curves[cmp];
@@ -301,25 +312,25 @@ bool DoViProcessor::intializeFrame(int frame, IScriptEnvironment* env, const uin
 }
 
 uint16_t DoViProcessor::processSample(int cmp, uint16_t bl, uint16_t el, uint16_t mmrBlY, uint16_t mmrBlU, uint16_t mmrBlV) const {
-	bl >>= (containerBitDepth - bl_bit_depth);
+	bl >>= (blContainerBitDepth - bl_bit_depth);
 	int pivot_idx = getPivotIndex(cmp, bl);
 	int v;
 	if (cmp == 0 || mapping_idc[cmp][pivot_idx] == 0) {
 		v = polynompialMapping(cmp, pivot_idx, bl);
 	}
 	else {
-		mmrBlY >>= (containerBitDepth - bl_bit_depth);
-		mmrBlU >>= (containerBitDepth - bl_bit_depth);
-		mmrBlV >>= (containerBitDepth - bl_bit_depth);
+		mmrBlY >>= (blContainerBitDepth - bl_bit_depth);
+		mmrBlU >>= (blContainerBitDepth - bl_bit_depth);
+		mmrBlV >>= (blContainerBitDepth - bl_bit_depth);
 		v = mmrMapping(cmp, pivot_idx, mmrBlY, mmrBlU, mmrBlV);
 	}
 	int r = 0;
 	if (!disable_residual_flag) {
-		el >>= (containerBitDepth - el_bit_depth);
+		el >>= (elContainerBitDepth - el_bit_depth);
 		r = nonLinearInverseQuantization(cmp, el);
 	}
 	uint16_t h = signalReconstruction(v, r);
-	h <<= (containerBitDepth - out_bit_depth);
+	h <<= (outContainerBitDepth - out_bit_depth);
 	return h;
 }
 
@@ -487,18 +498,18 @@ void DoViProcessor::prepareTrimCoef() {
 }
 
 void DoViProcessor::processTrim(uint16_t& ro, uint16_t& go, uint16_t& bo, const uint16_t& ri, const uint16_t& gi, const uint16_t& bi) const  {
-	float dr = pq2nits(ri >> (containerBitDepth - out_bit_depth));
-	float dg = pq2nits(gi >> (containerBitDepth - out_bit_depth));
-	float db = pq2nits(bi >> (containerBitDepth - out_bit_depth));
+	float dr = pq2nits(ri >> (outContainerBitDepth - out_bit_depth));
+	float dg = pq2nits(gi >> (outContainerBitDepth - out_bit_depth));
+	float db = pq2nits(bi >> (outContainerBitDepth - out_bit_depth));
 
 	float er = (trim.ccc[0] + dr * trim.ccc[1]) / (1 + dr * trim.ccc[2]);
 	float eg = (trim.ccc[0] + dg * trim.ccc[1]) / (1 + dg * trim.ccc[2]);
 	float eb = (trim.ccc[0] + db * trim.ccc[1]) / (1 + db * trim.ccc[2]);
 
 	if (trimInfoMissing) {
-		ro = nits2pq(er) << (containerBitDepth - out_bit_depth);
-		go = nits2pq(eg) << (containerBitDepth - out_bit_depth);
-		bo = nits2pq(eb) << (containerBitDepth - out_bit_depth);
+		ro = nits2pq(er) << (outContainerBitDepth - out_bit_depth);
+		go = nits2pq(eg) << (outContainerBitDepth - out_bit_depth);
+		bo = nits2pq(eb) << (outContainerBitDepth - out_bit_depth);
 	}	else {
 		float y3 = targetMaxNits;
 		float fr = powf((std::clamp(((er / y3) * trim.goP[0]) + trim.goP[1], 0.0f, 1.0f)), trim.goP[2]) * y3;
@@ -510,8 +521,8 @@ void DoViProcessor::processTrim(uint16_t& ro, uint16_t& go, uint16_t& bo, const 
 		float gg = fg * powf((1 + trim.cS[0]) * fg / Y, trim.cS[1]);
 		float gb = fb * powf((1 + trim.cS[0]) * fb / Y, trim.cS[1]);
 
-		ro = nits2pq(gr) << (containerBitDepth - out_bit_depth);
-		go = nits2pq(gg) << (containerBitDepth - out_bit_depth);
-		bo = nits2pq(gb) << (containerBitDepth - out_bit_depth);
+		ro = nits2pq(gr) << (outContainerBitDepth - out_bit_depth);
+		go = nits2pq(gg) << (outContainerBitDepth - out_bit_depth);
+		bo = nits2pq(gb) << (outContainerBitDepth - out_bit_depth);
 	}
 }

--- a/include/DoViProcessor.h
+++ b/include/DoViProcessor.h
@@ -35,7 +35,7 @@ typedef void (*f_dovi_rpu_free_vdr_dm_data)(const DoviVdrDmData* ptr);
 
 class DoViProcessor {
 public:
-  DoViProcessor(const char* rpuPath, IScriptEnvironment* env);
+  DoViProcessor(const char* rpuPath, IScriptEnvironment* env, uint8_t blContainerBits, uint8_t elContainerBits);
   virtual ~DoViProcessor();
   bool wasCreationSuccessful() { return successfulCreation; }
   void setRgbProof(bool set = true) { rgbProof = set; }
@@ -51,7 +51,7 @@ public:
   inline bool elProcessingDisabled() const { return disable_residual_flag; }
   inline bool trimProcessingDisabled() const { return skipTrim; }
   inline void forceDisableElProcessing(bool force = true) { disable_residual_flag = force; }
-  inline uint16_t getNlqOffset(int cmp) const { return nlq_offset[cmp] << (containerBitDepth - el_bit_depth); }
+  inline uint16_t getNlqOffset(int cmp) const { return nlq_offset[cmp] << (outContainerBitDepth - el_bit_depth); }
   inline uint16_t getMaxPq() const { return max_pq; }
   inline uint16_t getMaxContentLightLevel() const { return max_content_light_level; }
   const std::vector<uint16_t>& getAvailableTrimPqs() const { return availableTrimPqs; }
@@ -86,7 +86,7 @@ public:
   inline void sample2rgb(uint16_t& r, uint16_t& g, uint16_t& b, const uint16_t& y, const uint16_t& u, const uint16_t& v) const;
   void processTrim(uint16_t& ro, uint16_t& go, uint16_t& bo, const uint16_t& ri, const uint16_t& gi, const uint16_t& bi) const;
 
-  static const uint8_t containerBitDepth = 16;
+  static const uint8_t outContainerBitDepth = 16;
 private:
   static inline constexpr uint16_t Clip3(int lower, int upper, int value);
   void showMessage(const char* message, IScriptEnvironment* env);
@@ -118,6 +118,8 @@ private:
   bool skipTrim;
   bool trimInfoMissing;
 
+  const uint8_t blContainerBitDepth;
+  const uint8_t elContainerBitDepth;
   uint8_t bl_bit_depth;
   uint8_t el_bit_depth;
   uint8_t out_bit_depth;
@@ -135,7 +137,7 @@ private:
   uint32_t ycc_to_rgb_offset[3];
 
   static const uint16_t ycc_to_rgb_coef_scale_shifts = 13;
-  static const uint16_t ycc_to_rgb_offset_scale_shifts = (28-containerBitDepth);
+  static const uint16_t ycc_to_rgb_offset_scale_shifts = (28-outContainerBitDepth);
   static const uint16_t rgb_to_lms_coef_scale_shifts = 14;
 
   uint8_t num_pivots_minus1[3];

--- a/include/DoViProcessor.h
+++ b/include/DoViProcessor.h
@@ -22,8 +22,8 @@
 #pragma warning(pop)
 #include "rpu_parser.h"
 
-
 typedef DoviRpuOpaqueList* (*f_dovi_parse_rpu_bin_file)(const char* path);
+typedef DoviRpuOpaque* (*f_dovi_parse_unspec62_nalu)(const uint8_t* rpubuf, size_t rpusize);
 typedef void (*f_dovi_rpu_list_free)(DoviRpuOpaqueList* ptr);
 typedef const char* (*f_dovi_rpu_get_error)(const DoviRpuOpaque* ptr);
 typedef const DoviRpuDataHeader* (*f_dovi_rpu_get_header)(const DoviRpuOpaque* ptr);
@@ -42,8 +42,9 @@ public:
   void setNlqProof(bool set = true) { nlqProof = set; }
   inline void setTrim(uint16_t trimPq, float targetMinNits, float targetMaxNits);
 
-  bool intializeFrame(int frame, IScriptEnvironment* env);
+  bool intializeFrame(int frame, IScriptEnvironment* env, const uint8_t* rpubuf, size_t rpusize);
   inline int getClipLength() const { return rpus->len; }
+  inline bool isIntegratedRpu() const { return !rpus; }
   inline bool isFEL() const { return is_fel; }
   inline bool isSceneChange() const { return scene_refresh_flag; }
   inline bool isLimitedRangeOutput() const { return !signal_full_range_flag; }
@@ -101,6 +102,7 @@ private:
   DoviRpuOpaqueList* rpus;
 
   f_dovi_parse_rpu_bin_file dovi_parse_rpu_bin_file;
+  f_dovi_parse_unspec62_nalu dovi_parse_unspec62_nalu;
   f_dovi_rpu_list_free dovi_rpu_list_free;
   f_dovi_rpu_get_header dovi_rpu_get_header;
   f_dovi_rpu_free_header dovi_rpu_free_header;

--- a/include/rpu_parser.h
+++ b/include/rpu_parser.h
@@ -5,8 +5,8 @@
 
 
 #define RPU_PARSER_MAJOR 3
-#define RPU_PARSER_MINOR 1
-#define RPU_PARSER_PATCH 1
+#define RPU_PARSER_MINOR 2
+#define RPU_PARSER_PATCH 0
 
 
 #include <stddef.h>
@@ -51,6 +51,10 @@ typedef struct {
      * null pointer if not profile 7
      */
     const char *el_type;
+    /**
+     * Deprecated since 3.2.0
+     * The field is not actually part of the RPU header
+     */
     uint8_t rpu_nal_prefix;
     uint8_t rpu_type;
     uint16_t rpu_format;


### PR DESCRIPTION
Add compatibility to directly read the RPU from the stream, for streams load by ffms2. This is a new ffms2 feature that is currently being developed

With this neither the EL nor the RPU need to be extracted anymore!

Thus instead of:
bl=DGSource("blclip.dgi")
el=DGSource("elclip.dgi")
DoViBaker(bl,el,rpu="RPU.bin")

This can now be used:
bl=FFVideoSource("clip.ts", threads=1)
el=FFVideoSource("clip.ts", threads=1, track=1)
DoViBaker(bl,el)

This however is bought by a decoding speed of about half compared to using DGSource!