### PR TITLE
Throw error if rpus is nullptr

### DIFF
--- a/DoViBaker/DoViProcessor.cpp
+++ b/DoViBaker/DoViProcessor.cpp
@@ -31,7 +31,10 @@ DoViProcessor::DoViProcessor(const char* rpuPath, IScriptEnvironment* env, uint8
 
 	if (strlen(rpuPath)) {
 		rpus = dovi_parse_rpu_bin_file(rpuPath);
-		if (rpus->error) {
+		if (!rpus) {
+			showMessage("DoViBaker: parsing failed.", env);
+		}
+		else if (rpus->error) {
 			showMessage((std::string("DoViBaker: ") + rpus->error).c_str(), env);
 			return;
 		}


### PR DESCRIPTION
The pointer from `dovi_parse_rpu_bin_file` could be nullptr as per the description.