### PR TITLE
Fix another memory leak and set MT mode

### DIFF
--- a/DoViBaker/DoViBaker.cpp
+++ b/DoViBaker/DoViBaker.cpp
@@ -111,7 +111,6 @@ DoViBaker<quarterResolutionEl>::DoViBaker(
 template<int quarterResolutionEl>
 DoViBaker<quarterResolutionEl>::~DoViBaker()
 {
-	doviProc->~DoViProcessor();
 	delete doviProc;
 }
 

--- a/DoViBaker/DoViProcessor.cpp
+++ b/DoViBaker/DoViProcessor.cpp
@@ -52,7 +52,7 @@ DoViProcessor::DoViProcessor(const char* rpuPath, IScriptEnvironment* env, uint8
 
 DoViProcessor::~DoViProcessor()
 {
-	if (wasCreationSuccessful() && isIntegratedRpu()) {
+	if (wasCreationSuccessful() && !isIntegratedRpu()) {
 		dovi_rpu_list_free(rpus);
 	}
 }

--- a/include/DoViBaker.h
+++ b/include/DoViBaker.h
@@ -26,6 +26,10 @@ public:
     IScriptEnvironment* env);
   virtual ~DoViBaker();
   PVideoFrame GetFrame(int n, IScriptEnvironment* env) override;
+  int __stdcall SetCacheHints(int cachehints, int frame_range) override
+  {
+      return cachehints == CACHE_GET_MTMODE ? MT_MULTI_INSTANCE : 0;
+  }
 
 private:
   struct TimecubeLutFree {


### PR DESCRIPTION
`dovi_rpu_list_free(rpus);` was never executed.
`doviProc->~DoViProcessor();` is called on `delete doviProc;`.