### PR TITLE
Add parameter sourceProfile

### DIFF
--- a/DoViBaker/AvisynthEntry.cpp
+++ b/DoViBaker/AvisynthEntry.cpp
@@ -15,7 +15,7 @@ AVSValue __cdecl Create_RealDoViBaker(
   bool qnd,
   bool rgbProof,
   bool nlqProof,
-  const AVSValue* args, 
+  int sourceProfile,
   IScriptEnvironment* env)
 {
   if (!blclip->GetVideoInfo().HasVideo() || (elclip && !elclip->GetVideoInfo().HasVideo())) {
@@ -89,12 +89,16 @@ AVSValue __cdecl Create_RealDoViBaker(
       cubeNitsPairs.push_back(std::pair(nitsList[i], cubesList[i + 1]));
     }
   }
+
+  if (sourceProfile != 7 && sourceProfile != 8) {
+      env->ThrowError("DoViBaker: sourceProfile must be either 7 or 8.");
+  }
   
   if (quarterResolutionEl == 0) {
-    return new DoViBaker<false>(blclip, elclip, rpuPath, blClipChromaSubSampled, elClipChromaSubSampled, cubeNitsPairs, desiredTrimPq, targetMinNits, targetMaxNits, qnd, rgbProof, nlqProof, env);
+    return new DoViBaker<false>(blclip, elclip, rpuPath, blClipChromaSubSampled, elClipChromaSubSampled, cubeNitsPairs, desiredTrimPq, targetMinNits, targetMaxNits, qnd, rgbProof, nlqProof, sourceProfile, env);
   }
   if (quarterResolutionEl == 1) {
-    return new DoViBaker<true>(blclip, elclip, rpuPath, blClipChromaSubSampled, elClipChromaSubSampled, cubeNitsPairs, desiredTrimPq, targetMinNits, targetMaxNits, qnd, rgbProof, nlqProof, env);
+    return new DoViBaker<true>(blclip, elclip, rpuPath, blClipChromaSubSampled, elClipChromaSubSampled, cubeNitsPairs, desiredTrimPq, targetMinNits, targetMaxNits, qnd, rgbProof, nlqProof, sourceProfile, env);
   }
 }
 
@@ -116,7 +120,8 @@ AVSValue __cdecl Create_DoViBaker(AVSValue args, void* user_data, IScriptEnviron
     args[9].AsBool(false),
     args[10].AsBool(false),
     args[11].AsBool(false),
-    &args, env);
+    args[12].AsInt(7),
+    env);
 }
 
 const AVS_Linkage *AVS_linkage = nullptr;
@@ -125,7 +130,7 @@ extern "C" __declspec(dllexport) const char* __stdcall AvisynthPluginInit3(IScri
 {
   AVS_linkage = vectors;
 
-  env->AddFunction("DoViBaker", "c[el]c[rpu]s[cubes]s[mclls]s[cubes_basepath]s[trimPq]i[targetMaxNits]f[targetMinNits]f[qnd]b[rgbProof]b[nlqProof]b", Create_DoViBaker, 0);
+  env->AddFunction("DoViBaker", "c[el]c[rpu]s[cubes]s[mclls]s[cubes_basepath]s[trimPq]i[targetMaxNits]f[targetMinNits]f[qnd]b[rgbProof]b[nlqProof]b[sourceProfile]i", Create_DoViBaker, 0);
 
   return "Hey it is just a spectrogram!";
 }
@@ -304,7 +309,7 @@ int main(int argc, char** argv)
     return 1;
   }
   
-  DoViProcessor dovi(argv[1], NULL, DoViProcessor::outContainerBitDepth, DoViProcessor::outContainerBitDepth);
+  DoViProcessor dovi(argv[1], NULL, DoViProcessor::outContainerBitDepth, DoViProcessor::outContainerBitDepth, 0);
   if (!dovi.wasCreationSuccessful()) {
     return 1;
   }

--- a/DoViBaker/DoViBaker.cpp
+++ b/DoViBaker/DoViBaker.cpp
@@ -47,6 +47,7 @@ DoViBaker<quarterResolutionEl>::DoViBaker(
 	bool _qnd,
 	bool _rgbProof,
 	bool _nlqProof,
+	int sourceProfile,
 	IScriptEnvironment* env)
 	: GenericVideoFilter(_blChild)
 	, elChild(_elChild)
@@ -56,7 +57,7 @@ DoViBaker<quarterResolutionEl>::DoViBaker(
 {
 	int blContainerBits = vi.BitsPerComponent();
 	int elContainerBits = elChild ? elChild->GetVideoInfo().BitsPerComponent() : 0;
-	doviProc = new DoViProcessor(rpuPath, env, blContainerBits, elContainerBits);
+	doviProc = new DoViProcessor(rpuPath, env, blContainerBits, elContainerBits, sourceProfile);
 	if (!doviProc->wasCreationSuccessful()) {
 		env->ThrowError("DoViBaker: Cannot create object");
 	}

--- a/DoViBaker/DoViProcessor.cpp
+++ b/DoViBaker/DoViProcessor.cpp
@@ -5,7 +5,7 @@
 #include "DoViProcessor.h"
 
 
-DoViProcessor::DoViProcessor(const char* rpuPath, IScriptEnvironment* env, uint8_t blContainerBits, uint8_t elContainerBits)
+DoViProcessor::DoViProcessor(const char* rpuPath, IScriptEnvironment* env, uint8_t blContainerBits, uint8_t elContainerBits, const int _sourceProfile)
 	: successfulCreation(false)
 	, rgbProof(false)
 	, nlqProof(false)
@@ -14,6 +14,7 @@ DoViProcessor::DoViProcessor(const char* rpuPath, IScriptEnvironment* env, uint8
 	, rpus(0x0)
 	, blContainerBitDepth(blContainerBits)
 	, elContainerBitDepth(elContainerBits)
+	, sourceProfile(_sourceProfile)
 {
 	ycc_to_rgb_coef[0] = 8192;
 	ycc_to_rgb_coef[1] = 0;
@@ -82,6 +83,10 @@ bool DoViProcessor::intializeFrame(int frame, IScriptEnvironment* env, const uin
 		const char* error = dovi_rpu_get_error(rpu);
 		showMessage((std::string("DoViBaker: ") + error).c_str(), env);
 		return false;
+	}
+
+	if (header->guessed_profile != sourceProfile) {
+		showMessage("DoViBaker: sourceProfile is different than the RPU profile.", env);
 	}
 
 	const DoviRpuDataMapping* mapping_data = dovi_rpu_get_data_mapping(rpu);

--- a/include/DoViBaker.h
+++ b/include/DoViBaker.h
@@ -23,6 +23,7 @@ public:
     bool qnd, 
     bool rgbProof, 
     bool nlqProof,
+    int sourceProfile,
     IScriptEnvironment* env);
   virtual ~DoViBaker();
   PVideoFrame GetFrame(int n, IScriptEnvironment* env) override;

--- a/include/DoViProcessor.h
+++ b/include/DoViProcessor.h
@@ -24,7 +24,7 @@
 
 class DoViProcessor {
 public:
-  DoViProcessor(const char* rpuPath, IScriptEnvironment* env, uint8_t blContainerBits, uint8_t elContainerBits);
+  DoViProcessor(const char* rpuPath, IScriptEnvironment* env, uint8_t blContainerBits, uint8_t elContainerBits, const int sourceProfile);
   virtual ~DoViProcessor();
   bool wasCreationSuccessful() { return successfulCreation; }
   void setRgbProof(bool set = true) { rgbProof = set; }
@@ -151,6 +151,7 @@ private:
     float goP[3];
     float cS[2];
   } trim;
+  const int sourceProfile;
 };
 
 void DoViProcessor::setTrim(uint16_t trimPq, float targetMinNits, float targetMaxNits)


### PR DESCRIPTION
Currently one can process RPU.bin with different profile than the video. The new parameter prevents such scenarios.